### PR TITLE
Extending number of functions in erlgeom module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,7 @@ clean:
 	./rebar clean
 	rm -fr priv
 
-
+dialyzer-build: build
+	dialyzer --build_plt --output_plt erlgeom.plt \
+        -o dialyzer.build \
+        -r src ebin

--- a/README.md
+++ b/README.md
@@ -49,12 +49,14 @@ more examples.
     2> erlgeom:from_geom(Geom3).
     {'LineString', [[3,3],[7,7]]}
 
-    3> Geom1 = erlgeom:to_geom({'LineString', [[4,4],[10,10]]}),
-    3> erlgeom:get_centroid(Geom1).
-    {'Point',[7.0,7.0]}
+    3> WktReader = erlgeom:wktreader_create(),
+    3> Geom2 = erlgeom:wktreader_read(WktReader, 
+    3>    "POLYGON((0 0, 1 1, 1 2, 1 1, 0 0))"),
+    3> erlgeom:is_valid(Geom2).
+    false
 
     4> Geom1 = erlgeom:to_geom({'LineString', [[4,4],[10,10]]}),
-    4> Geom2 = erlgeom:get_centroid_geom(Geom1),
+    4> Geom2 = erlgeom:get_centroid(Geom1),
     4> erlgeom:from_geom(Geom2).
     {'Point',[7.0,7.0]}
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+Install
+-------
+
 Build it with:
 
     make
@@ -5,29 +8,6 @@ Build it with:
 Run tests with:
 
     make check
-
-Here's an example session in the erlang shell. See the src/erlgeom.erl file for
-more examples.
-
-    $ erl -pa ebin
-    Erlang R14B03 (erts-5.8.4) [source] [64-bit] [smp:4:4] [rq:4] [async-threads:0] [kernel-poll:false]
-
-    Eshell V5.8.4  (abort with ^G)
-    1> Geom1 = erlgeom:to_geom({'Point',[5,5]}).
-    geom: POINT (5.0000000000000000 5.0000000000000000)
-    <<>>
-    2> Geom2 = erlgeom:to_geom({'LineString', [[1,1],[14,14]]}).
-    geom: LINESTRING (1.0000000000000000 1.0000000000000000, 14.0000000000000000 14.0000000000000000)
-    <<>>
-    3> erlgeom:disjoint(Geom1, Geom2).
-    false
-    4> Geom3 = erlgeom:to_geom({'Point', [2.5,65.7]}).
-    geom: POINT (2.5000000000000000 65.7000000000000028)
-    <<>>
-    5> erlgeom:disjoint(Geom1, Geom3).
-    true
-    6>
-
 
 On Windows
 ----------
@@ -45,3 +25,85 @@ Now set it up so that GEOS and Erlang can be found:
 And finally compile the whole thing:
 
     rebar compile
+
+
+Examples
+--------
+
+Here's an example session in the erlang shell. See the src/erlgeom.erl file for
+more examples.
+
+    $ erl -pa ebin
+    Erlang R14B03 (erts-5.8.4) [source] [64-bit] [smp:4:4] [rq:4] [async-threads:0] [kernel-poll:false]
+
+    Eshell V5.8.4  (abort with ^G)
+
+    1> Geom1 = erlgeom:to_geom({'LineString', [[3,3],[10,10]]}),
+    1> Geom2 = erlgeom:to_geom({'LineString', [[1,1],[7,7]]}),
+    1> erlgeom:intersects(Geom1, Geom2).
+    true
+
+    2> Geom1 = erlgeom:to_geom({'LineString', [[3,3],[10,10]]}),
+    2> Geom2 = erlgeom:to_geom({'LineString', [[1,1],[7,7]]}),
+    2> Geom3 = erlgeom:intersection(Geom1, Geom2),
+    2> erlgeom:from_geom(Geom3).
+    {'LineString', [[3,3],[7,7]]}
+
+    3> Geom1 = erlgeom:to_geom({'LineString', [[4,4],[10,10]]}),
+    3> erlgeom:get_centroid(Geom1).
+    {'Point',[7.0,7.0]}
+
+    4> Geom1 = erlgeom:to_geom({'LineString', [[4,4],[10,10]]}),
+    4> Geom2 = erlgeom:get_centroid_geom(Geom1),
+    4> erlgeom:from_geom(Geom2).
+    {'Point',[7.0,7.0]}
+
+    5> Geom1 = erlgeom:to_geom({'LineString', [[4,4], [4.5, 4.5], [10,10]]}),
+    5> erlgeom:topology_preserve_simplify(Geom1, 1).
+    {'LineString',[[4.0,4.0],[10.0,10.0]]}
+
+    6> Geom1 = erlgeom:to_geom({'LineString', [[4,4], [4.5, 4.5], [10,10]]}),
+    6> erlgeom:is_valid(Geom1).
+    true
+
+    7> WktReader = erlgeom:wktreader_create(),
+    7> Geom = erlgeom:wktreader_read(WktReader, "POINT(10 10)"),
+    7> erlgeom:from_geom(Geom).
+    {'Point',[10.0,10.0]}
+
+    8> WktReader = erlgeom:wktreader_create(),
+    8> Geom = erlgeom:wktreader_read(WktReader, "POINT(10.0 10.0)"),
+    8> WkbWriter = erlgeom:wkbwriter_create(),
+    8> Bin = erlgeom:wkbwriter_write(WkbWriter, Geom),
+    8> WkbReader = erlgeom:wkbreader_create(),
+    8> Geom2 = erlgeom:wkbreader_read(WkbReader, Bin),
+    8> erlgeom:from_geom(Geom2).
+    {'Point',[10.0,10.0]}
+
+    9> WkbReader = erlgeom:wkbreader_create(),
+    9> Geom = erlgeom:wkbreader_readhex(WkbReader,
+    9>     "010100000000000000000024400000000000002440"),
+    9> erlgeom:from_geom(Geom).
+    {'Point',[10.0,10.0]}
+
+    10> WktReader = erlgeom:wktreader_create(),
+    10> Geom = erlgeom:wktreader_read(WktReader, "POINT(10 10)"),
+    10> WktWriter = erlgeom:wktwriter_create(),
+    10> erlgeom:wktwriter_write(WktWriter, Geom).
+    "Point(10.0000000000000000 10.0000000000000000)"
+
+    11> WktReader = erlgeom:wktreader_create(),
+    11> Geom = erlgeom:wktreader_read(WktReader, "POINT(10.0 10.0)"),
+    11> WkbWriter = erlgeom:wkbwriter_create(),
+    11> erlgeom:wkbwriter_write(WkbWriter, Geom).
+    <<1,1,0,0,0,0,0,0,0,0,0,36,64,0,0,0,0,0,0,36,64>>
+
+    12> WktReader = erlgeom:wktreader_create(),
+    12> Geom = erlgeom:wktreader_read(WktReader, "POINT(10.0 10.0)"),
+    12> WkbWriter = erlgeom:wkbwriter_create(),
+    12> erlgeom:wkbwriter_writehex(WkbWriter, Geom).
+    "010100000000000000000024400000000000002440"
+
+
+
+

--- a/c_src/erlgeom.c
+++ b/c_src/erlgeom.c
@@ -534,7 +534,7 @@ intersection(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         return 0;
     }
 
-    if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom2)) {
+    if(!enif_get_resource(env, argv[1], GEOSGEOM_RESOURCE, (void**)&geom2)) {
         return 0;
     }
 

--- a/c_src/erlgeom.c
+++ b/c_src/erlgeom.c
@@ -424,27 +424,11 @@ geom_to_eterm(ErlNifEnv *env, const GEOSGeometry *geom)
     return -1;
 }
 
-// SRTRTree
-//typedef struct {
-//    int size;
-//    GEOSGeometry* geom[100];
-//} GeosSTRtree_cb_t;
 typedef struct {
     int size;
     GEOSGeometry** geom[100];
 } GeosSTRtree_cb_t;
-//void
-//geosstrtree_cb(void *item, void *acc) {
-//    GeosSTRtree_cb_t *result_ptr  = (GeosSTRtree_cb_t *) acc;
-//    if (result_ptr->size < 100) {
-//        GEOSGeometry *geom = (GEOSGeometry *) item;
-//        result_ptr->geom[result_ptr->size] = geom;
-//        result_ptr->size += 1;
-//    } else {
-//	    fprintf(stderr, "Geometries returned more than 100, skipping: %d.\n",
-//            result_ptr->size);
-//    }
-//} 
+
 void
 geosstrtree_cb(void *item, void *acc) {
     GeosSTRtree_cb_t *result_ptr  = (GeosSTRtree_cb_t *) acc;
@@ -1127,13 +1111,7 @@ geosstrtree_query(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     ERL_NIF_TERM *arr = (ERL_NIF_TERM *) malloc(sizeof(ERL_NIF_TERM)*result.size);
     int index = 0;
     for (; index<result.size; index++) {
-        //GEOSGeometry **geom = \
-        //    enif_alloc_resource(GEOSGEOM_RESOURCE, sizeof(GEOSGeometry*));
-        //*geom = result.geom[index];
-        //arr[index] = enif_make_resource(env, geom);
         arr[index] = enif_make_resource(env, result.geom[index]);
-
-        //enif_release_resource(geom);
     }
 
     eterm = enif_make_tuple_from_array(env, arr, index);
@@ -1165,13 +1143,7 @@ geosstrtree_iterate(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     ERL_NIF_TERM *arr = (ERL_NIF_TERM *) malloc(sizeof(ERL_NIF_TERM)*result.size);
     int index = 0;
     for (; index<result.size; index++) {
-        //GEOSGeometry **geom = \
-        //    enif_alloc_resource(GEOSGEOM_RESOURCE, sizeof(GEOSGeometry*));
-        //*geom = result.geom[index];
-        //arr[index] = enif_make_resource(env, geom);
         arr[index] = enif_make_resource(env, result.geom[index]);
-
-        //enif_release_resource(geom);
     }
 
     eterm = enif_make_tuple_from_array(env, arr, index);

--- a/c_src/erlgeom.c
+++ b/c_src/erlgeom.c
@@ -709,6 +709,9 @@ topology_preserve_simplify(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 Geom1 = erlgeom:to_geom({'LineString', [[4,4], [4.5, 4.5], [10,10]]}),
 erlgeom:is_valid(Geom1).
 true
+Geom2 = erlgeom:wktreader_read(WktReader,"POLYGON((0 0, 1 1, 1 2, 1 1, 0 0))"),
+erlgeom:is_valid(Geom2).
+false
 */
 static ERL_NIF_TERM
 is_valid(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])

--- a/c_src/erlgeom.c
+++ b/c_src/erlgeom.c
@@ -1189,6 +1189,7 @@ geosstrtree_query(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         //fprintf(stderr, "Points: %d\n",
         //    GEOSGeomGetNumPoints(*(acc.geoms[index])));
         arr[index] = enif_make_resource(env, acc.geoms[index]);
+        enif_make_resource(env, acc.geoms[index]);
     }
 
     eterm = enif_make_tuple_from_array(env, arr, index);
@@ -1228,8 +1229,10 @@ geosstrtree_iterate(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         (ERL_NIF_TERM *) enif_alloc(sizeof(ERL_NIF_TERM)*acc.count);
     int index = 0;
     for (; index<acc.count; index++) {
-        //fprintf(stderr, "Points: %d\n", GEOSGeomGetNumPoints(*(acc.geoms[index])));
+        //fprintf(stderr, "Points: %d\n",
+        //  GEOSGeomGetNumPoints(*(acc.geoms[index])));
         arr[index] = enif_make_resource(env, acc.geoms[index]);
+        enif_make_resource(env, acc.geoms[index]);
     }
 
     eterm = enif_make_tuple_from_array(env, arr, index);

--- a/c_src/erlgeom.c
+++ b/c_src/erlgeom.c
@@ -48,7 +48,7 @@ set_GEOSCoordSeq_from_eterm_list(GEOSCoordSequence *seq, int pos,
             dbl_coord = int_coord;
         }
         else if (!enif_get_double(env, head, &dbl_coord)) {
-            return 0;
+            return enif_make_badarg(env);
         }
         GEOSCoordSeq_setX(seq, pos, dbl_coord);
 
@@ -57,12 +57,12 @@ set_GEOSCoordSeq_from_eterm_list(GEOSCoordSequence *seq, int pos,
             dbl_coord = int_coord;
         }
         else if (!enif_get_double(env, head, &dbl_coord)) {
-            return 0;
+            return enif_make_badarg(env);
         }
         GEOSCoordSeq_setY(seq, pos, dbl_coord);
         return 1;
     }
-    return 0;
+    return enif_make_badarg(env);
 }
 
 GEOSGeometry*
@@ -569,11 +569,11 @@ disjoint(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     GEOSGeometry **geom2;
 
     if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom1)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     if(!enif_get_resource(env, argv[1], GEOSGEOM_RESOURCE, (void**)&geom2)) {
-        return 0;
+        return enif_make_badarg(env);
     }
     
     int result;
@@ -599,10 +599,10 @@ intersects(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     GEOSGeometry **geom2;
 
     if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom1)) {
-        return 0;
+        return enif_make_badarg(env);
     }
     if(!enif_get_resource(env, argv[1], GEOSGEOM_RESOURCE, (void**)&geom2)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     int result;
@@ -637,11 +637,11 @@ intersection(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     ERL_NIF_TERM eterm;
 
     if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom1)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     if(!enif_get_resource(env, argv[1], GEOSGEOM_RESOURCE, (void**)&geom2)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     GEOSGeometry **result_geom = \
@@ -672,7 +672,7 @@ get_centroid(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     ERL_NIF_TERM eterm;
 
     if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     GEOSGeometry **result_geom = \
@@ -705,13 +705,13 @@ topology_preserve_simplify(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     ERL_NIF_TERM eterm;
 
     if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom)) {
-        return 0;
+        return enif_make_badarg(env);
     }
     if (enif_get_int(env, argv[1], &int_tol)) {
         dbl_tol = int_tol;
     }
     else if (!enif_get_double(env, argv[1], &dbl_tol)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     simpler_geom = GEOSTopologyPreserveSimplify(*geom, dbl_tol);
@@ -740,7 +740,7 @@ is_valid(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     GEOSGeometry **geom1;
 
     if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom1)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     int isvalid;
@@ -792,17 +792,17 @@ wktreader_read(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     if(!enif_get_resource(env, argv[0], GEOSWKTREADER_RESOURCE,
         (void**)&wkt_reader)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     unsigned len;
     if (!enif_get_list_length(env, argv[1], &len)){
-        return 0;
+        return enif_make_badarg(env);
     }
     char *wkt = enif_alloc(sizeof(char)*(len+1));
 
     if(!enif_get_string(env, argv[1], wkt, len+1, ERL_NIF_LATIN1)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     GEOSGeometry **geom = \
@@ -853,7 +853,7 @@ wkbreader_read(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     if(!enif_get_resource(env, argv[0], GEOSWKBREADER_RESOURCE,
         (void**)&wkb_reader)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     if (!enif_inspect_binary(env, argv[1], &bin)){
@@ -885,18 +885,18 @@ wkbreader_readhex(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     if(!enif_get_resource(env, argv[0], GEOSWKBREADER_RESOURCE,
         (void**)&wkb_reader)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     unsigned len;
     if (!enif_get_list_length(env, argv[1], &len)){
-        return 0;
+        return enif_make_badarg(env);
     }
     char *wkb_hex = enif_alloc(sizeof(char)*(len+1));
 
     // TODO: Specific message in cases < 0, == 0 
     if(enif_get_string(env, argv[1], wkb_hex, len+1, ERL_NIF_LATIN1) <= 0) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     GEOSGeometry **geom = \
@@ -943,11 +943,11 @@ wktwriter_write(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     if(!enif_get_resource(env, argv[0], GEOSWKTWRITER_RESOURCE,
         (void**)&wkt_writer)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     if(!enif_get_resource(env, argv[1], GEOSGEOM_RESOURCE, (void**)&geom)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     char *wkt = GEOSWKTWriter_write(*wkt_writer, *geom);
@@ -990,11 +990,11 @@ wkbwriter_write(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     if(!enif_get_resource(env, argv[0], GEOSWKBWRITER_RESOURCE,
         (void**)&wkb_writer)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     if(!enif_get_resource(env, argv[1], GEOSGEOM_RESOURCE, (void**)&geom)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     size_t size;
@@ -1025,11 +1025,11 @@ wkbwriter_writehex(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     if(!enif_get_resource(env, argv[0], GEOSWKBWRITER_RESOURCE,
         (void**)&wkb_writer)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     if(!enif_get_resource(env, argv[1], GEOSGEOM_RESOURCE, (void**)&geom)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     size_t size;
@@ -1080,11 +1080,11 @@ geosstrtree_insert(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     GEOSGeometry **geom;
 
     if(!enif_get_resource(env, argv[0], GEOSSTRTREE_RESOURCE, (void**)&tree)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     if(!enif_get_resource(env, argv[1], GEOSGEOM_RESOURCE, (void**)&geom)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     //GEOSSTRtree_insert(*tree, GEOSEnvelope(*geom), *geom);
@@ -1112,11 +1112,11 @@ geosstrtree_query(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     ERL_NIF_TERM eterm;
 
     if(!enif_get_resource(env, argv[0], GEOSSTRTREE_RESOURCE, (void**)&tree)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     if(!enif_get_resource(env, argv[1], GEOSGEOM_RESOURCE, (void**)&geom)) {
-        return 0;
+        return enif_make_badarg(env);
     }
    
     GeosSTRtree_cb_t result = { .size = 0 };
@@ -1148,7 +1148,7 @@ geosstrtree_iterate(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     ERL_NIF_TERM eterm;
 
     if(!enif_get_resource(env, argv[0], GEOSSTRTREE_RESOURCE, (void**)&tree)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     GeosSTRtree_cb_t result = { .size = 0 };
@@ -1184,11 +1184,11 @@ geosstrtree_remove(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     GEOSGeometry **geom;
 
     if(!enif_get_resource(env, argv[0], GEOSSTRTREE_RESOURCE, (void**)&tree)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     if(!enif_get_resource(env, argv[1], GEOSGEOM_RESOURCE, (void**)&geom)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     //char remove = GEOSSTRtree_remove(*tree, GEOSEnvelope(*geom), *geom);
@@ -1225,7 +1225,7 @@ ERL_NIF_TERM from_geom(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
     ERL_NIF_TERM eterm;
 
     if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom)) {
-        return 0;
+        return enif_make_badarg(env);
     }
 
     eterm = geom_to_eterm(env, *geom);

--- a/c_src/erlgeom.c
+++ b/c_src/erlgeom.c
@@ -624,34 +624,12 @@ intersection(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
 /*
 Geom1 = erlgeom:to_geom({'LineString', [[4,4],[10,10]]}),
-erlgeom:get_centroid(Geom1).
-{'Point',[7.0,7.0]}
-*/
-static ERL_NIF_TERM
-get_centroid(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
-{
-    GEOSGeometry **geom;
-    GEOSGeometry *centroid_geom;
-    ERL_NIF_TERM eterm;
-
-    if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom)) {
-        return 0;
-    }
-
-    centroid_geom = GEOSGetCentroid(*geom);
-    eterm = geom_to_eterm(env, centroid_geom);
-    GEOSGeom_destroy(centroid_geom);
-    return eterm;
-}
-
-/*
-Geom1 = erlgeom:to_geom({'LineString', [[4,4],[10,10]]}),
 Geom2 = erlgeom:get_centroid_geom(Geom1),
 erlgeom:from_geom(Geom2).
 {'Point',[7.0,7.0]}
 */
 static ERL_NIF_TERM
-get_centroid_geom(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+get_centroid(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     GEOSGeometry **geom;
     ERL_NIF_TERM eterm;
@@ -1057,7 +1035,6 @@ static ErlNifFunc nif_funcs[] =
     {"disjoint", 2, disjoint},
     {"from_geom", 1, from_geom},
     {"get_centroid", 1, get_centroid},
-    {"get_centroid_geom", 1, get_centroid_geom},
     {"intersection", 2, intersection},
     {"intersects", 2, intersects},
     {"is_valid", 1, is_valid},

--- a/c_src/erlgeom.c
+++ b/c_src/erlgeom.c
@@ -1155,9 +1155,7 @@ geosstrtree_insert(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         return enif_make_badarg(env);
     }
     ERL_NIF_TERM copy = enif_make_copy((**tree).env, argv[2]);
-    enif_make_copy((**tree).env, argv[2]);
     GEOSSTRtree_insert((**tree).tree, GEOSEnvelope(*geom), (void *)copy);
-    //GEOSSTRtree_insert((**tree).tree, GEOSEnvelope(*geom), (void *)argv[2]);
     return enif_make_atom(env, "ok");
 }
 

--- a/c_src/erlgeom.c
+++ b/c_src/erlgeom.c
@@ -568,6 +568,10 @@ disjoint(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     GEOSGeometry **geom1;
     GEOSGeometry **geom2;
 
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
+
     if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom1)) {
         return enif_make_badarg(env);
     }
@@ -597,6 +601,10 @@ intersects(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     GEOSGeometry **geom1;
     GEOSGeometry **geom2;
+
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
 
     if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom1)) {
         return enif_make_badarg(env);
@@ -636,6 +644,10 @@ intersection(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     GEOSGeometry **geom2;
     ERL_NIF_TERM eterm;
 
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
+
     if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom1)) {
         return enif_make_badarg(env);
     }
@@ -671,6 +683,10 @@ get_centroid(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     GEOSGeometry **geom;
     ERL_NIF_TERM eterm;
 
+    if (argc != 1) {
+        return enif_make_badarg(env);
+    }
+
     if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom)) {
         return enif_make_badarg(env);
     }
@@ -703,6 +719,10 @@ topology_preserve_simplify(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     double dbl_tol;
     int int_tol;
     ERL_NIF_TERM eterm;
+
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
 
     if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom)) {
         return enif_make_badarg(env);
@@ -738,6 +758,10 @@ static ERL_NIF_TERM
 is_valid(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     GEOSGeometry **geom1;
+
+    if (argc != 1) {
+        return enif_make_badarg(env);
+    }
 
     if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom1)) {
         return enif_make_badarg(env);
@@ -789,6 +813,10 @@ wktreader_read(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     GEOSWKTReader **wkt_reader;
     ERL_NIF_TERM eterm;
+
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
 
     if(!enif_get_resource(env, argv[0], GEOSWKTREADER_RESOURCE,
         (void**)&wkt_reader)) {
@@ -851,6 +879,10 @@ wkbreader_read(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     ErlNifBinary bin;
     ERL_NIF_TERM eterm;
 
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
+
     if(!enif_get_resource(env, argv[0], GEOSWKBREADER_RESOURCE,
         (void**)&wkb_reader)) {
         return enif_make_badarg(env);
@@ -882,6 +914,10 @@ wkbreader_readhex(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     GEOSWKBReader **wkb_reader;
     ERL_NIF_TERM eterm;
+
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
 
     if(!enif_get_resource(env, argv[0], GEOSWKBREADER_RESOURCE,
         (void**)&wkb_reader)) {
@@ -941,6 +977,10 @@ wktwriter_write(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     GEOSGeometry **geom;
     ERL_NIF_TERM eterm;
 
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
+
     if(!enif_get_resource(env, argv[0], GEOSWKTWRITER_RESOURCE,
         (void**)&wkt_writer)) {
         return enif_make_badarg(env);
@@ -988,6 +1028,10 @@ wkbwriter_write(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     GEOSGeometry **geom;
     ERL_NIF_TERM eterm;
 
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
+
     if(!enif_get_resource(env, argv[0], GEOSWKBWRITER_RESOURCE,
         (void**)&wkb_writer)) {
         return enif_make_badarg(env);
@@ -1022,6 +1066,10 @@ wkbwriter_writehex(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     GEOSWKBWriter **wkb_writer;
     GEOSGeometry **geom;
     ERL_NIF_TERM eterm;
+
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
 
     if(!enif_get_resource(env, argv[0], GEOSWKBWRITER_RESOURCE,
         (void**)&wkb_writer)) {
@@ -1079,6 +1127,10 @@ geosstrtree_insert(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     GEOSSTRtree **tree;
     GEOSGeometry **geom;
 
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
+
     if(!enif_get_resource(env, argv[0], GEOSSTRTREE_RESOURCE, (void**)&tree)) {
         return enif_make_badarg(env);
     }
@@ -1110,6 +1162,10 @@ geosstrtree_query(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     GEOSSTRtree **tree;
     GEOSGeometry **geom;
     ERL_NIF_TERM eterm;
+
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
 
     if(!enif_get_resource(env, argv[0], GEOSSTRTREE_RESOURCE, (void**)&tree)) {
         return enif_make_badarg(env);
@@ -1147,6 +1203,10 @@ geosstrtree_iterate(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     GEOSSTRtree **tree;
     ERL_NIF_TERM eterm;
 
+    if (argc != 1) {
+        return enif_make_badarg(env);
+    }
+
     if(!enif_get_resource(env, argv[0], GEOSSTRTREE_RESOURCE, (void**)&tree)) {
         return enif_make_badarg(env);
     }
@@ -1182,6 +1242,10 @@ geosstrtree_remove(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     GEOSSTRtree **tree;
     GEOSGeometry **geom;
+
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
 
     if(!enif_get_resource(env, argv[0], GEOSSTRTREE_RESOURCE, (void**)&tree)) {
         return enif_make_badarg(env);
@@ -1223,6 +1287,10 @@ static
 ERL_NIF_TERM from_geom(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
     GEOSGeometry **geom;
     ERL_NIF_TERM eterm;
+
+    if (argc != 1) {
+        return enif_make_badarg(env);
+    }
 
     if(!enif_get_resource(env, argv[0], GEOSGEOM_RESOURCE, (void**)&geom)) {
         return enif_make_badarg(env);

--- a/rebar_makecheck.config
+++ b/rebar_makecheck.config
@@ -1,5 +1,5 @@
 {erl_opts, [debug_info, warn_unused_vars, warn_shadow_vars, warn_unused_import,
-    {d, makecheck}]}.
+    export_all]}.
 
 {port_specs, [
     {"priv/erlgeom.so", ["c_src/*.c"]}

--- a/src/erlgeom.erl
+++ b/src/erlgeom.erl
@@ -24,8 +24,19 @@
     intersects/2,
     is_valid/1,
     topology_preserve_simplify/2,
-    to_geom/1
+    to_geom/1,
+    wkbreader_create/0,
+    wkbreader_read/2,
+    wkbreader_readhex/2,
+    wkbwriter_create/0,
+    wkbwriter_write/2,
+    wkbwriter_writehex/2,
+    wktreader_create/0,
+    wktreader_read/2,
+    wktwriter_create/0,
+    wktwriter_write/2
     ]).
+
 -ifdef(makecheck).
 -compile(export_all).
 -endif.
@@ -67,6 +78,37 @@ is_valid(_Geom1) ->
 
 topology_preserve_simplify(_Geom1, _Tolerance) ->
     "NIF library not loaded".
+
+wkbreader_create() ->
+    "NIF library not loaded".
+
+wkbreader_read(_WKBReader, _Wkb) ->
+    "NIF library not loaded".
+
+wkbreader_readhex(_WKBReader, _WkbHex) ->
+    "NIF library not loaded".
+
+wkbwriter_create() ->
+    "NIF library not loaded".
+
+wkbwriter_write(_WKBWriter, _Geom) ->
+    "NIF library not loaded".
+
+wkbwriter_writehex(_WKBWriter, _Geom) ->
+    "NIF library not loaded".
+
+wktreader_create() ->
+    "NIF library not loaded".
+
+wktreader_read(_WKTReader, _Wkt) ->
+    "NIF library not loaded".
+
+wktwriter_create() ->
+    "NIF library not loaded".
+
+wktwriter_write(_WKTWriter, _Geom) ->
+    "NIF library not loaded".
+
 
 % @doc Convert a GeoCouch geometry to a GEOS geometry, validate
 % the structure of the geometry.

--- a/src/erlgeom.erl
+++ b/src/erlgeom.erl
@@ -19,10 +19,10 @@
     disjoint/2,
     from_geom/1,
     geosstrtree_create/0,
-    geosstrtree_insert/2,
+    geosstrtree_insert/3,
     geosstrtree_iterate/1,
     geosstrtree_query/2,
-    geosstrtree_remove/2,
+    geosstrtree_remove/3,
     get_centroid/1,
     intersection/2,
     intersects/2,
@@ -65,7 +65,7 @@ disjoint(_Geom1, _Geom2) ->
 geosstrtree_create() ->
     erlang:nif_error(nif_not_loaded).
 
-geosstrtree_insert(_RTree, _Geom) ->
+geosstrtree_insert(_RTree, _Geom, _Eterm) ->
     erlang:nif_error(nif_not_loaded).
 
 geosstrtree_iterate(_RTree) ->
@@ -74,7 +74,7 @@ geosstrtree_iterate(_RTree) ->
 geosstrtree_query(_Rtree, _Geom) ->
     erlang:nif_error(nif_not_loaded).
 
-geosstrtree_remove(_RTree, _Geom) ->
+geosstrtree_remove(_RTree, _Geom, _Eterm) ->
     erlang:nif_error(nif_not_loaded).
 
 get_centroid(_Geom1) ->

--- a/src/erlgeom.erl
+++ b/src/erlgeom.erl
@@ -55,7 +55,13 @@ init() ->
             filename:join(["priv", "erlgeom"])
         end;
     Dir ->
-        filename:join(Dir, "erlgeom")
+        case os:getenv("ESCRIPT") of
+        "1" ->
+            filename:join([filename:dirname(escript:script_name()),
+                "..", "lib", "escript", "erlgeom"]);
+        _ ->
+            filename:join(Dir, "erlgeom")
+        end
     end,
     (catch erlang:load_nif(SoName, 0)).
 

--- a/src/erlgeom.erl
+++ b/src/erlgeom.erl
@@ -58,7 +58,7 @@ init() ->
         case os:getenv("ESCRIPT") of
         "1" ->
             filename:join([filename:dirname(escript:script_name()),
-                "..", "lib", "escript", "erlgeom"]);
+                "..", "lib", "erlgeom"]);
         _ ->
             filename:join(Dir, "erlgeom")
         end

--- a/src/erlgeom.erl
+++ b/src/erlgeom.erl
@@ -22,7 +22,7 @@
     geosstrtree_insert/3,
     geosstrtree_iterate/1,
     geosstrtree_query/2,
-    geosstrtree_remove/3,
+    %%geosstrtree_remove/3,
     get_centroid/1,
     intersection/2,
     intersects/2,
@@ -74,8 +74,8 @@ geosstrtree_iterate(_RTree) ->
 geosstrtree_query(_Rtree, _Geom) ->
     erlang:nif_error(nif_not_loaded).
 
-geosstrtree_remove(_RTree, _Geom, _Eterm) ->
-    erlang:nif_error(nif_not_loaded).
+%%geosstrtree_remove(_RTree, _Geom, _Eterm) ->
+%%    erlang:nif_error(nif_not_loaded).
 
 get_centroid(_Geom1) ->
     erlang:nif_error(nif_not_loaded).

--- a/src/erlgeom.erl
+++ b/src/erlgeom.erl
@@ -18,6 +18,11 @@
     to_geom_validate/1,
     disjoint/2,
     from_geom/1,
+    geosstrtree_create/0,
+    geosstrtree_insert/2,
+    geosstrtree_iterate/1,
+    geosstrtree_query/2,
+    geosstrtree_remove/2,
     get_centroid/1,
     intersection/2,
     intersects/2,
@@ -58,6 +63,21 @@ init() ->
     (catch erlang:load_nif(SoName, 0)).
 
 disjoint(_Geom1, _Geom2) ->
+    "NIF library not loaded".
+
+geosstrtree_create() ->
+    "NIF library not loaded".
+
+geosstrtree_insert(_RTree, _Geom) ->
+    "NIF library not loaded".
+
+geosstrtree_iterate(_RTree) ->
+    "NIF library not loaded".
+
+geosstrtree_query(_Rtree, _Geom) ->
+    "NIF library not loaded".
+
+geosstrtree_remove(_RTree, _Geom) ->
     "NIF library not loaded".
 
 get_centroid(_Geom1) ->

--- a/src/erlgeom.erl
+++ b/src/erlgeom.erl
@@ -14,9 +14,18 @@
 
 -module(erlgeom).
 
--export([disjoint/2, from_geom/1, to_geom/1,
-    topology_preserve_simplify/2, to_geom_validate/1]).
-
+-export([
+    to_geom_validate/1,
+    disjoint/2,
+    from_geom/1,
+    get_centroid/1,
+    get_centroid_geom/1,
+    intersection/2,
+    intersects/2,
+    is_valid/1,
+    topology_preserve_simplify/2,
+    to_geom/1
+    ]).
 -ifdef(makecheck).
 -compile(export_all).
 -endif.
@@ -39,6 +48,21 @@ init() ->
     (catch erlang:load_nif(SoName, 0)).
 
 disjoint(_Geom1, _Geom2) ->
+    "NIF library not loaded".
+
+get_centroid(_Geom1) ->
+    "NIF library not loaded".
+
+get_centroid_geom(_Geom1) ->
+    "NIF library not loaded".
+
+intersection(_Geom1, _Geom2) ->
+    "NIF library not loaded".
+
+intersects(_Geom1, _Geom2) ->
+    "NIF library not loaded".
+
+is_valid(_Geom1) ->
     "NIF library not loaded".
 
 topology_preserve_simplify(_Geom1, _Tolerance) ->

--- a/src/erlgeom.erl
+++ b/src/erlgeom.erl
@@ -60,67 +60,67 @@ init() ->
     (catch erlang:load_nif(SoName, 0)).
 
 disjoint(_Geom1, _Geom2) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 geosstrtree_create() ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 geosstrtree_insert(_RTree, _Geom) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 geosstrtree_iterate(_RTree) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 geosstrtree_query(_Rtree, _Geom) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 geosstrtree_remove(_RTree, _Geom) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 get_centroid(_Geom1) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 intersection(_Geom1, _Geom2) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 intersects(_Geom1, _Geom2) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 is_valid(_Geom1) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 topology_preserve_simplify(_Geom1, _Tolerance) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 wkbreader_create() ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 wkbreader_read(_WKBReader, _Wkb) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 wkbreader_readhex(_WKBReader, _WkbHex) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 wkbwriter_create() ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 wkbwriter_write(_WKBWriter, _Geom) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 wkbwriter_writehex(_WKBWriter, _Geom) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 wktreader_create() ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 wktreader_read(_WKTReader, _Wkt) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 wktwriter_create() ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 wktwriter_write(_WKTWriter, _Geom) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 
 % @doc Convert a GeoCouch geometry to a GEOS geometry, validate
@@ -224,8 +224,8 @@ all2(Fun, [H|T]) ->
 
 % @doc Convert a GeoCouch geometry to a GEOS geometry
 to_geom(_Geom) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).
 
 % @doc Convert a GEOS geometry to a GeoCouch geometry
 from_geom(_Geom) ->
-    "NIF library not loaded".
+    erlang:nif_error(nif_not_loaded).

--- a/src/erlgeom.erl
+++ b/src/erlgeom.erl
@@ -41,9 +41,6 @@
     wktwriter_write/2
     ]).
 
--ifdef(makecheck).
--compile(export_all).
--endif.
 
 -on_load(init/0).
 

--- a/src/erlgeom.erl
+++ b/src/erlgeom.erl
@@ -19,7 +19,6 @@
     disjoint/2,
     from_geom/1,
     get_centroid/1,
-    get_centroid_geom/1,
     intersection/2,
     intersects/2,
     is_valid/1,
@@ -62,9 +61,6 @@ disjoint(_Geom1, _Geom2) ->
     "NIF library not loaded".
 
 get_centroid(_Geom1) ->
-    "NIF library not loaded".
-
-get_centroid_geom(_Geom1) ->
     "NIF library not loaded".
 
 intersection(_Geom1, _Geom2) ->

--- a/test/002-functions.t
+++ b/test/002-functions.t
@@ -159,20 +159,20 @@ test_intersection() ->
 test_geosstrtree_create() ->
     GeosSTRtree = erlgeom:geosstrtree_create(),
     Geoms = erlgeom:geosstrtree_iterate(GeosSTRtree),
-    etap:is(Geoms, {}, "STRTree creation works.").
+    etap:is(Geoms, [], "STRTree creation works.").
 
 test_geosstrtree_insert() ->
     GeosSTRtree = erlgeom:geosstrtree_create(),
     Ls1 = {'LineString', [[1.0,1.0],[5.0,5.0]]},
     Geom1 = erlgeom:to_geom(Ls1),
-    erlgeom:geosstrtree_insert(GeosSTRtree, Geom1),
-    Geoms = erlgeom:geosstrtree_iterate(GeosSTRtree),
-    etap:is(tuple_size(Geoms), 1, "STRTree insertion works.").
+    erlgeom:geosstrtree_insert(GeosSTRtree, Geom1, Ls1),
+    [Element1 | Tail] = erlgeom:geosstrtree_iterate(GeosSTRtree),
+    etap:is(Element1, Ls1, "STRTree insertion works.").
 
 test_geosstrtree_iterate() ->
     GeosSTRtree = erlgeom:geosstrtree_create(),
     Geoms = erlgeom:geosstrtree_iterate(GeosSTRtree),
-    etap:is(tuple_size(Geoms), 0,"STRTree iteration works.").
+    etap:is(length(Geoms), 0,"STRTree iteration works.").
 
 test_geosstrtree_query() ->
     GeosSTRtree = erlgeom:geosstrtree_create(),
@@ -182,22 +182,22 @@ test_geosstrtree_query() ->
     Geom2 = erlgeom:to_geom(Ls2),
     Ls3 = {'LineString', [[3.0,3.0],[6.0,6.0]]},
     Geom3 = erlgeom:to_geom(Ls3),
-    erlgeom:geosstrtree_insert(GeosSTRtree, Geom1),
-    erlgeom:geosstrtree_insert(GeosSTRtree, Geom2),
-    erlgeom:geosstrtree_insert(GeosSTRtree, Geom3),
+    erlgeom:geosstrtree_insert(GeosSTRtree, Geom1, Ls1),
+    erlgeom:geosstrtree_insert(GeosSTRtree, Geom2, Ls2),
+    erlgeom:geosstrtree_insert(GeosSTRtree, Geom3, Ls3),
     Ls4 = {'LineString', [[6.0,6.0],[7.0,7.0]]},
     Geom4 = erlgeom:to_geom(Ls4),
     Geoms = erlgeom:geosstrtree_query(GeosSTRtree, Geom4),
-    etap:is(tuple_size(Geoms), 2, "STRTree query works.").
+    etap:is(length(Geoms), 2, "STRTree query works.").
 
 test_geosstrtree_remove() ->
     GeosSTRtree = erlgeom:geosstrtree_create(),
     Ls1 = {'LineString', [[3.0,3.0],[6.0,6.0]]},
     Geom1 = erlgeom:to_geom(Ls1),
-    erlgeom:geosstrtree_insert(GeosSTRtree, Geom1),
-    erlgeom:geosstrtree_remove(GeosSTRtree, Geom1),
+    erlgeom:geosstrtree_insert(GeosSTRtree, Geom1, Ls1),
+    erlgeom:geosstrtree_remove(GeosSTRtree, Geom1, Ls1),
     Geoms = erlgeom:geosstrtree_query(GeosSTRtree, Geom1),
-    etap:is(tuple_size(Geoms), 0, "STRTree remove works.").
+    etap:is(length(Geoms), 0, "STRTree remove works.").
 
 test_get_centroid() ->
     Pt = {'Point',[3,3]},

--- a/test/002-functions.t
+++ b/test/002-functions.t
@@ -17,12 +17,30 @@ main(_) ->
     code:add_pathz("test"),
     code:add_pathz("ebin"),
 
-    etap:plan(3),
+    etap:plan(8),
+    test_get_centroid(),
+    test_get_centroid_geom(),
     test_disjoint(),
+    test_intersection(),
+    test_intersects(),
+    test_is_valid(),
     test_simplify(),
 
     etap:end_tests().
 
+test_get_centroid() ->
+    Pt = {'Point',[3,3]},
+    Pt1 = erlgeom:to_geom(Pt),
+    Centroid = erlgeom:get_centroid(Pt1),
+    etap:is(Centroid, Pt,
+        "Point get_centroid works").
+
+test_get_centroid_geom() ->
+    Pt = {'Point',[3,3]},
+    Pt1 = erlgeom:to_geom(Pt),
+    CentroidGeom = erlgeom:get_centroid_geom(Pt1),
+    etap:is(erlgeom:from_geom(CentroidGeom), Pt,
+        "Point get_centroid_geom works").
 
 test_disjoint() ->
     Pt = {'Point',[3.0, 3.0]},
@@ -30,36 +48,69 @@ test_disjoint() ->
     Pt1 = erlgeom:to_geom(Pt),
     Ls1 = erlgeom:to_geom(Ls),
     Disjoint = erlgeom:disjoint(Pt1, Ls1),
-    etap:is(Disjoint, false, "Geometries are not disjoint"),
+    etap:is(Disjoint, false,
+        "Geometries are not disjoint"),
 
     % Some geometries are based on the GeoJSON specification
     % http://geojson.org/geojson-spec.html (2010-08-17)
     Geoms = [
         {'Point', [100.0, 0.0]},
-        {'LineString', [[100.0, 0.0], [101.0, 1.0]]},
-        {'Polygon', [
-            [[100.0, 0.0], [101.0, 0.0], [100.0, 1.0], [100.0, 0.0]]
+        {'LineString', [
+            [100.0, 0.0],
+            [101.0, 1.0]
         ]},
         {'Polygon', [
-            [[100.0, 0.0], [101.0, 0.0], [100.0, 1.0], [100.0, 0.0]],
-            [[100.2, 0.2], [100.6, 0.2], [100.2, 0.6], [100.2, 0.2]]
+            [[100.0, 0.0], 
+             [101.0, 0.0],
+             [100.0, 1.0],
+             [100.0, 0.0]]
         ]},
-        {'MultiPoint', [[100.0, 0.0], [101.0, 1.0]]},
+        {'Polygon', [
+            [[100.0, 0.0],
+             [101.0, 0.0],
+             [100.0, 1.0],
+             [100.0, 0.0]],
+            [[100.2, 0.2],
+             [100.6, 0.2],
+             [100.2, 0.6],
+             [100.2, 0.2]]
+        ]},
+        {'MultiPoint', [
+            [100.0, 0.0],
+            [101.0, 1.0]
+        ]},
         {'MultiLineString', [
-            [[100.0, 0.0], [101.0, 1.0]],
-            [[102.0, 2.0], [103.0, 3.0]]
+            [[100.0, 0.0],
+             [101.0, 1.0]],
+            [[102.0, 2.0],
+             [103.0, 3.0]]
         ]},
         {'MultiPolygon', [
             [
-                [[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]
+                [[102.0, 2.0],
+                 [103.0, 2.0],
+                 [103.0, 3.0],
+                 [102.0, 3.0],
+                 [102.0, 2.0]]
             ],[
-                [[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
-                [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]
+                [[100.0, 0.0],
+                 [101.0, 0.0],
+                 [101.0, 1.0],
+                 [100.0, 1.0],
+                 [100.0, 0.0]],
+                [[100.2, 0.2],
+                 [100.8, 0.2],
+                 [100.8, 0.8],
+                 [100.2, 0.8],
+                 [100.2, 0.2]]
             ]
         ]},
         {'GeometryCollection', [
             {'Point', [100.0, 0.0]},
-            {'LineString', [[101.0, 0.0], [102.0, 1.0]]}
+            {'LineString', [
+                [101.0, 0.0],
+                [102.0, 1.0]
+            ]}
         ]}
     ],
 
@@ -90,7 +141,52 @@ test_disjoint() ->
     etap:is(Results, [true,true,true,true,true,true, false, false],
         "Two geometries are not disjoint").
 
+test_intersection() ->
+    Geom1 = erlgeom:to_geom({'LineString', [[1,1],[10,10]]}),
+    Geom2 = erlgeom:to_geom({'LineString', [[2,2],[9,9]]}),
+    Intersection = {'LineString', [[2,2],[9,9]]},
+    Intersection1 = erlgeom:intersection(Geom1, Geom2),
+    etap:is(erlgeom:from_geom(Intersection1), Intersection,
+        "Linestrings intersection works").
+
+test_intersects() ->
+    Geom1 = erlgeom:to_geom({'LineString', [[1,1],[10,10]]}),
+    Geom2 = erlgeom:to_geom({'LineString', [[2,2],[9,9]]}),
+    etap:is(erlgeom:intersects(Geom1, Geom2), true,
+        "Linestrings intersects works").
+
+test_is_valid() ->
+    Geom1 = erlgeom:to_geom({'LineString', [[1,1],[10,10]]}),
+    etap:is(erlgeom:is_valid(Geom1), true,
+        "Linestrings is_valid works").
+
 test_simplify() ->
-    Polygon = {'Polygon', [[[-43.59375, -0.3515625], [-31.640625, 15.8203125], [-33.046875, 25.6640625], [-37.265625, 39.7265625], [-34.453125, 67.8515625], [6.328125, 58.7109375], [21.09375, 65.0390625], [35.15625, 63.6328125], [78.046875, 63.6328125], [75.234375, 48.1640625], [65.390625, 33.3984375], [43.59375, 36.2109375], [-6.328125, 36.2109375], [-0.703125, 31.9921875], [2.109375, 5.9765625], [3.515625, -16.5234375], [-17.578125, -19.3359375], [-24.609375, -5.9765625], [-40.078125, -11.6015625], [-40.078125, -11.6015625], [-43.59375, -0.3515625]]]},
-    {'Polygon', [NewCoords]} = erlgeom:topology_preserve_simplify(erlgeom:to_geom(Polygon), 30.0),
+    Polygon = {'Polygon', [[
+        [-43.59375, -0.3515625],
+        [-31.640625, 15.8203125],
+        [-33.046875, 25.6640625],
+        [-37.265625, 39.7265625],
+        [-34.453125, 67.8515625],
+        [6.328125, 58.7109375],
+        [21.09375, 65.0390625],
+        [35.15625, 63.6328125],
+        [78.046875, 63.6328125],
+        [75.234375, 48.1640625],
+        [65.390625, 33.3984375],
+        [43.59375, 36.2109375],
+        [-6.328125, 36.2109375],
+        [-0.703125, 31.9921875],
+        [2.109375, 5.9765625],
+        [3.515625, -16.5234375],
+        [-17.578125, -19.3359375],
+        [-24.609375, -5.9765625],
+        [-40.078125, -11.6015625],
+        [-40.078125, -11.6015625],
+        [-43.59375, -0.3515625]]]},
+    {'Polygon', 
+        [NewCoords]} = erlgeom:topology_preserve_simplify(
+            erlgeom:to_geom(Polygon),
+            30.0),
     etap:is(length(NewCoords), 6, "Geometry was simplified").
+
+

--- a/test/002-functions.t
+++ b/test/002-functions.t
@@ -17,10 +17,15 @@ main(_) ->
     code:add_pathz("test"),
     code:add_pathz("ebin"),
 
-    etap:plan(14),
+    etap:plan(19),
     test_disjoint(),
     test_intersects(),
     test_intersection(),
+    test_geosstrtree_create(),
+    test_geosstrtree_insert(),
+    test_geosstrtree_iterate(),
+    test_geosstrtree_query(),
+    test_geosstrtree_remove(),
     test_get_centroid(),
     test_topology_preserve_simplify(),
     test_is_valid__true(),
@@ -150,6 +155,49 @@ test_intersection() ->
     Intersection1 = erlgeom:intersection(Geom1, Geom2),
     etap:is(erlgeom:from_geom(Intersection1), Intersection,
         "Linestrings intersection works").
+
+test_geosstrtree_create() ->
+    GeosSTRtree = erlgeom:geosstrtree_create(),
+    Geoms = erlgeom:geosstrtree_iterate(GeosSTRtree),
+    etap:is(Geoms, {}, "STRTree creation works.").
+
+test_geosstrtree_insert() ->
+    GeosSTRtree = erlgeom:geosstrtree_create(),
+    Ls1 = {'LineString', [[1.0,1.0],[5.0,5.0]]},
+    Geom1 = erlgeom:to_geom(Ls1),
+    erlgeom:geosstrtree_insert(GeosSTRtree, Geom1),
+    Geoms = erlgeom:geosstrtree_iterate(GeosSTRtree),
+    etap:is(tuple_size(Geoms), 1, "STRTree insertion works.").
+
+test_geosstrtree_iterate() ->
+    GeosSTRtree = erlgeom:geosstrtree_create(),
+    Geoms = erlgeom:geosstrtree_iterate(GeosSTRtree),
+    etap:is(tuple_size(Geoms), 0,"STRTree iteration works.").
+
+test_geosstrtree_query() ->
+    GeosSTRtree = erlgeom:geosstrtree_create(),
+    Ls1 = {'LineString', [[1.0,1.0],[5.0,5.0]]},
+    Geom1 = erlgeom:to_geom(Ls1),
+    Ls2 = {'LineString', [[1.0,1.0],[7.0,7.0]]},
+    Geom2 = erlgeom:to_geom(Ls2),
+    Ls3 = {'LineString', [[3.0,3.0],[6.0,6.0]]},
+    Geom3 = erlgeom:to_geom(Ls3),
+    erlgeom:geosstrtree_insert(GeosSTRtree, Geom1),
+    erlgeom:geosstrtree_insert(GeosSTRtree, Geom2),
+    erlgeom:geosstrtree_insert(GeosSTRtree, Geom3),
+    Ls4 = {'LineString', [[6.0,6.0],[7.0,7.0]]},
+    Geom4 = erlgeom:to_geom(Ls4),
+    Geoms = erlgeom:geosstrtree_query(GeosSTRtree, Geom4),
+    etap:is(tuple_size(Geoms), 2, "STRTree query works.").
+
+test_geosstrtree_remove() ->
+    GeosSTRtree = erlgeom:geosstrtree_create(),
+    Ls1 = {'LineString', [[3.0,3.0],[6.0,6.0]]},
+    Geom1 = erlgeom:to_geom(Ls1),
+    erlgeom:geosstrtree_insert(GeosSTRtree, Geom1),
+    erlgeom:geosstrtree_remove(GeosSTRtree, Geom1),
+    Geoms = erlgeom:geosstrtree_query(GeosSTRtree, Geom1),
+    etap:is(tuple_size(Geoms), 0, "STRTree remove works.").
 
 test_get_centroid() ->
     Pt = {'Point',[3,3]},

--- a/test/002-functions.t
+++ b/test/002-functions.t
@@ -152,7 +152,7 @@ test_intersection() ->
     Geom1 = erlgeom:to_geom({'LineString', [[1,1],[10,10]]}),
     Geom2 = erlgeom:to_geom({'LineString', [[2,2],[9,9]]}),
     Intersection = {'LineString', [[2,2],[9,9]]},
-    Intersection1 = erlgeom:intersection(Geom1, Geom2),
+    {ok, Intersection1} = erlgeom:intersection(Geom1, Geom2),
     etap:is(erlgeom:from_geom(Intersection1), Intersection,
         "Linestrings intersection works").
 
@@ -202,7 +202,7 @@ test_geosstrtree_remove() ->
 test_get_centroid() ->
     Pt = {'Point',[3,3]},
     Pt1 = erlgeom:to_geom(Pt),
-    CentroidGeom = erlgeom:get_centroid(Pt1),
+    {ok, CentroidGeom} = erlgeom:get_centroid(Pt1),
     etap:is(erlgeom:from_geom(CentroidGeom), Pt,
         "Point get_centroid_geom works").
 

--- a/test/002-functions.t
+++ b/test/002-functions.t
@@ -17,7 +17,7 @@ main(_) ->
     code:add_pathz("test"),
     code:add_pathz("ebin"),
 
-    etap:plan(19),
+    etap:plan(18),
     test_disjoint(),
     test_intersects(),
     test_intersection(),
@@ -25,7 +25,7 @@ main(_) ->
     test_geosstrtree_insert(),
     test_geosstrtree_iterate(),
     test_geosstrtree_query(),
-    test_geosstrtree_remove(),
+    %%test_geosstrtree_remove(),
     test_get_centroid(),
     test_topology_preserve_simplify(),
     test_is_valid__true(),
@@ -166,7 +166,7 @@ test_geosstrtree_insert() ->
     Ls1 = {'LineString', [[1.0,1.0],[5.0,5.0]]},
     Geom1 = erlgeom:to_geom(Ls1),
     erlgeom:geosstrtree_insert(GeosSTRtree, Geom1, Ls1),
-    [Element1 | Tail] = erlgeom:geosstrtree_iterate(GeosSTRtree),
+    [Element1 | _] = erlgeom:geosstrtree_iterate(GeosSTRtree),
     etap:is(Element1, Ls1, "STRTree insertion works.").
 
 test_geosstrtree_iterate() ->
@@ -190,14 +190,14 @@ test_geosstrtree_query() ->
     Geoms = erlgeom:geosstrtree_query(GeosSTRtree, Geom4),
     etap:is(length(Geoms), 2, "STRTree query works.").
 
-test_geosstrtree_remove() ->
-    GeosSTRtree = erlgeom:geosstrtree_create(),
-    Ls1 = {'LineString', [[3.0,3.0],[6.0,6.0]]},
-    Geom1 = erlgeom:to_geom(Ls1),
-    erlgeom:geosstrtree_insert(GeosSTRtree, Geom1, Ls1),
-    erlgeom:geosstrtree_remove(GeosSTRtree, Geom1, Ls1),
-    Geoms = erlgeom:geosstrtree_query(GeosSTRtree, Geom1),
-    etap:is(length(Geoms), 0, "STRTree remove works.").
+%%test_geosstrtree_remove() ->
+%%    GeosSTRtree = erlgeom:geosstrtree_create(),
+%%    Ls1 = {'LineString', [[3.0,3.0],[6.0,6.0]]},
+%%    Geom1 = erlgeom:to_geom(Ls1),
+%%    erlgeom:geosstrtree_insert(GeosSTRtree, Geom1, Ls1),
+%%    erlgeom:geosstrtree_remove(GeosSTRtree, Geom1, Ls1),
+%%    Geoms = erlgeom:geosstrtree_query(GeosSTRtree, Geom1),
+%%    etap:is(length(Geoms), 0, "STRTree remove works.").
 
 test_get_centroid() ->
     Pt = {'Point',[3,3]},

--- a/test/002-functions.t
+++ b/test/002-functions.t
@@ -253,7 +253,7 @@ test_is_valid__false() ->
 % Reader and Writer APIs
 
 test_wktreader_read() ->
-    Pt = {'Point', [10,10]},
+    Pt = {'Point', [10.0, 10.0]},
     WktReader = erlgeom:wktreader_create(),
     Geom1 = erlgeom:wktreader_read(WktReader, "POINT(10.0 10.0)"),
     Pt1 = erlgeom:from_geom(Geom1), 


### PR DESCRIPTION
New functions supported are:

```
get_centroid/1
intersection/2
intersects/2
is_valid/1
wkbreader_create/0
wkbreader_read/2
wkbreader_readhex/2
wkbwriter_create/0
wkbwriter_write/2
wkbwriter_writehex/2
wktreader_create/0
wktreader_read/2
wktwriter_create/0
wktwriter_write/2
```

Test cases  were added and README .md was updated to include more examples.
